### PR TITLE
Avoid overread in headerless FIFO example

### DIFF
--- a/examples/bmi270/fifo_watermark_headerless_mode/fifo_watermark_headerless_mode.c
+++ b/examples/bmi270/fifo_watermark_headerless_mode/fifo_watermark_headerless_mode.c
@@ -179,8 +179,7 @@ int main(void)
             accel_frame_length = BMI2_FIFO_ACCEL_FRAME_COUNT;
             gyro_frame_length = BMI2_FIFO_GYRO_FRAME_COUNT;
 
-            printf("\nFIFO data bytes available : %d \n", fifo_length);
-            printf("\nFIFO data bytes requested : %d \n", fifoframe.length);
+            fifoframe.length = fifo_length;
 
             /* Read FIFO data. */
             rslt = bmi2_read_fifo_data(&fifoframe, &bmi2_dev);


### PR DESCRIPTION
Overreading the FIFO doesn't provide any value in this example. Furthermore, bmi2_extract_accel and other extract functions rely on the fifoframe.length parameter to be correct in order to adjust the read length (i.e. in parse_fifo_accel_len, if the read would go beyond the end of the FIFO, only the remaining available bytes are extracted).

This is not an issue in this exact example because the BMI2_FIFO_ACCEL_FRAME_COUNT define matches the number of samples at the watermark level. But generally, the definition of the accel_length length parameter of function bmi2_extract_accel as an in/out parameter indicates that the bmi2_extract_accel function can return a lower number of accel samples than the accel_length requests (and it does set the accel_length the the true number of samples extracted before returning). This can only function if the fifoframe.length parameter does not reach into overread 0x8000 data.

Equivalent changes may be necessary for gyr, aux and other examples.