### PR TITLE
Fix INT1_IO_CTRL and INT2_IO_CTRL config when using SPI 4 wire: do not use burst writes

### DIFF
--- a/bmi2.c
+++ b/bmi2.c
@@ -2256,7 +2256,9 @@ int8_t bmi2_set_int_pin_config(const struct bmi2_int_pin_config *int_cfg, struct
     int8_t rslt;
 
     /* Variable to define data array */
-    uint8_t data_array[3] = { 0 };
+    uint8_t data_int1 = 0;
+    uint8_t data_int2 = 0;
+    uint8_t data_int_latch = 0;
 
     /* Variable to store register data */
     uint8_t reg_data = 0;
@@ -2273,14 +2275,16 @@ int8_t bmi2_set_int_pin_config(const struct bmi2_int_pin_config *int_cfg, struct
         if ((int_pin > BMI2_INT_NONE) && (int_pin < BMI2_INT_PIN_MAX))
         {
             /* Get the previous configuration data */
-            rslt = bmi2_get_regs(BMI2_INT1_IO_CTRL_ADDR, data_array, 3, dev);
+            rslt = bmi2_get_regs(BMI2_INT1_IO_CTRL_ADDR, &data_int1, 1, dev);
+            rslt = bmi2_get_regs(BMI2_INT2_IO_CTRL_ADDR, &data_int2, 1, dev);
+            rslt = bmi2_get_regs(BMI2_INT_LATCH_ADDR, &data_int_latch, 1, dev);
             if (rslt == BMI2_OK)
             {
                 /* Set interrupt pin 1 configuration */
                 if ((int_pin == BMI2_INT1) || (int_pin == BMI2_INT_BOTH))
                 {
                     /* Configure active low or high */
-                    reg_data = BMI2_SET_BITS(data_array[0], BMI2_INT_LEVEL, int_cfg->pin_cfg[0].lvl);
+                    reg_data = BMI2_SET_BITS(data_int1, BMI2_INT_LEVEL, int_cfg->pin_cfg[0].lvl);
 
                     /* Configure push-pull or open drain */
                     reg_data = BMI2_SET_BITS(reg_data, BMI2_INT_OPEN_DRAIN, int_cfg->pin_cfg[0].od);
@@ -2292,14 +2296,14 @@ int8_t bmi2_set_int_pin_config(const struct bmi2_int_pin_config *int_cfg, struct
                     reg_data = BMI2_SET_BITS(reg_data, BMI2_INT_INPUT_EN, int_cfg->pin_cfg[0].input_en);
 
                     /* Copy the data to be written in the respective array */
-                    data_array[0] = reg_data;
+                    data_int1 = reg_data;
                 }
 
                 /* Set interrupt pin 2 configuration */
                 if ((int_pin == BMI2_INT2) || (int_pin == BMI2_INT_BOTH))
                 {
                     /* Configure active low or high */
-                    reg_data = BMI2_SET_BITS(data_array[1], BMI2_INT_LEVEL, int_cfg->pin_cfg[1].lvl);
+                    reg_data = BMI2_SET_BITS(data_int2, BMI2_INT_LEVEL, int_cfg->pin_cfg[1].lvl);
 
                     /* Configure push-pull or open drain */
                     reg_data = BMI2_SET_BITS(reg_data, BMI2_INT_OPEN_DRAIN, int_cfg->pin_cfg[1].od);
@@ -2311,17 +2315,19 @@ int8_t bmi2_set_int_pin_config(const struct bmi2_int_pin_config *int_cfg, struct
                     reg_data = BMI2_SET_BITS(reg_data, BMI2_INT_INPUT_EN, int_cfg->pin_cfg[1].input_en);
 
                     /* Copy the data to be written in the respective array */
-                    data_array[1] = reg_data;
+                    data_int2 = reg_data;
                 }
 
                 /* Configure the interrupt mode */
-                data_array[2] = BMI2_SET_BIT_POS0(data_array[2], BMI2_INT_LATCH, int_cfg->int_latch);
+                data_int_latch = BMI2_SET_BIT_POS0(data_int_latch, BMI2_INT_LATCH, int_cfg->int_latch);
 
-                /* Set the configurations simultaneously as
+                /* Do not set the configurations simultaneously:
                  * INT1_IO_CTRL, INT2_IO_CTRL, and INT_LATCH lie
-                 * in consecutive addresses
+                 * in consecutive addresses, but there is a HW bug when using SPI
                  */
-                rslt = bmi2_set_regs(BMI2_INT1_IO_CTRL_ADDR, data_array, 3, dev);
+                rslt = bmi2_set_regs(BMI2_INT1_IO_CTRL_ADDR, &data_int1, 1, dev);
+                rslt = bmi2_set_regs(BMI2_INT2_IO_CTRL_ADDR, &data_int2, 1, dev);
+                rslt = bmi2_set_regs(BMI2_INT_LATCH_ADDR, &data_int_latch, 1, dev);
             }
         }
         else


### PR DESCRIPTION
There is a BUG when using SPI 4 lines, enabling interrupt output pins doesn't work. The issue is doing a 3 byte burst write. This is likely a HW issue on the IMU side. (?)

[Here](https://drive.google.com/drive/folders/1EJMbTIeq7Ks10NCOmVpXwdYiL7O3fGqQ?usp=share_link) you can see captures from a logic analyzer. Can be viewed using this [tool](https://www.saleae.com/downloads/).
`D5` (INT1_IOCTRL_RW_ENABLE (debug)) is active when doing operations with `INT1_IO_CTRL == 0x53` register. 
The relevant trace is for `bmi2_set_int_pin_config` function:
1. First we read 3 bytes from 0x53 (INT1_IO_CTRL) (to do read-modify-write)
2. We set the config values, and write 3 bytes to 0x53
3. Reading back the values from 0x53 results in zeroes.

Note that setting the interrupt latch mode seems to be working, so the issue is limited to registers `0x53 (INT1_IO_CTRL)` and `0x54 (INT2_IO_CTRL)`

SPI write HAL implementation:

```
BMI2_INTF_RETURN_TYPE bmi2_spi_write(uint8_t reg_addr, const uint8_t *reg_data, uint32_t len, void *intf_ptr)
{
    uint8_t dev_addr = *(uint8_t*)intf_ptr;

    HAL_GPIO_SET(dev_addr, 0);
    HAL_SPI_Transmit(&reg_addr, 1);
    HAL_SPI_Transmit((uint8_t *)reg_data, len);
    HAL_GPIO_SET(dev_addr, 1);

    return BMI2_OK;
}
```
Which respects datasheet section 6.4:
```
Multiple write operations are possible by keeping CSB low and continuing the data transfer. Only the first register’s
address has to be placed in SDX. Addresses are automatically incremented after each write access as long as CSB
stays active low. The principle of multiple write is shown in figure below:
```

Other details: SPI speed was set to 1 MHz, CPOL/CPHASE 1/1. Changing these settings didn't affect the outcome.

