### PR TITLE
feat: Add `skip_reset` `bmi270_init`, preventing soft reset during init

### DIFF
--- a/bmi2.c
+++ b/bmi2.c
@@ -1881,6 +1881,11 @@ static int8_t validate_foc_accel_axis(int16_t avg_foc_data, struct bmi2_dev *dev
  */
 int8_t bmi2_sec_init(struct bmi2_dev *dev)
 {
+    return bmi2_sec_init_with_opt(dev, 0);
+}
+
+int8_t bmi2_sec_init_with_opt(struct bmi2_dev *dev, uint8_t skip_reset)
+{
     /* Variable to define error */
     int8_t rslt;
 
@@ -1927,6 +1932,8 @@ int8_t bmi2_sec_init(struct bmi2_dev *dev)
                      *  re-mapping in the device structure
                      */
                     dev->remap = axes_remap;
+
+                    if (skip_reset) return BMI2_OK;
 
                     /* Perform soft-reset to bring all register values to their
                      * default values

--- a/bmi2.h
+++ b/bmi2.h
@@ -89,6 +89,8 @@ extern "C" {
  */
 int8_t bmi2_sec_init(struct bmi2_dev *dev);
 
+int8_t bmi2_sec_init_with_opt(struct bmi2_dev *dev, uint8_t skip_reset);
+
 /*!
  * \ingroup bmi2ApiInit
  * \page bmi2_api_bmi2_set_spi_en bmi2_set_spi_en

--- a/bmi270.c
+++ b/bmi270.c
@@ -1351,7 +1351,7 @@ static int8_t disable_sensor_features(uint64_t sensor_sel, struct bmi2_dev *dev)
  *  4) Updates the feature offset parameters in the device structure.
  *  5) Updates the maximum number of pages, in the device structure.
  */
-int8_t bmi270_init(struct bmi2_dev *dev)
+int8_t bmi270_init(struct bmi2_dev *dev, uint8_t skip_reset)
 {
     /* Variable to define error */
     int8_t rslt;
@@ -1389,7 +1389,7 @@ int8_t bmi270_init(struct bmi2_dev *dev)
         }
 
         /* Initialize BMI2 sensor */
-        rslt = bmi2_sec_init(dev);
+        rslt = bmi2_sec_init_with_opt(dev, skip_reset);
         if (rslt == BMI2_OK)
         {
             /* Assign the offsets of the feature input

--- a/bmi270.h
+++ b/bmi270.h
@@ -150,7 +150,7 @@ extern "C" {
  * @retval 0 -> Success
  * @retval < 0 -> Fail
  */
-int8_t bmi270_init(struct bmi2_dev *dev);
+int8_t bmi270_init(struct bmi2_dev *dev, uint8_t skip_reset);
 
 /**
  * \ingroup bmi270


### PR DESCRIPTION
This PR adds `skip_reset` option to `bmi270_init`. Useful when waking up from sleep and the IMU has already initialized. Preventing the soft reset lets us read IMU regs to get activity data (such as step count) while we were asleep.